### PR TITLE
Add functionality for custom markdown macros

### DIFF
--- a/testproject/testproject/settings/base.py
+++ b/testproject/testproject/settings/base.py
@@ -25,6 +25,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 from .unversioned import SECRET_KEY
 
 # to set DEBUG = True, import dev.py into local.py
+
 DEBUG = False
 
 ALLOWED_HOSTS = ['*']
@@ -55,6 +56,7 @@ INSTALLED_APPS = [
     'wiki.plugins.categories',
     'wiki.plugins.categories.editor',
     'wiki.plugins.metadata',
+    'markdown-macros',
 ]
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'


### PR DESCRIPTION
Nathan, is this the right place to add a package extending python-markdown? The text would be run though a python function md.convert(text). Is there a sensible place to run that?
https://github.com/wnielson/markdown-macros/blob/master/example.py